### PR TITLE
[FEATURE config] Add a PR note with a link to the full change set

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
       "vulnerabilityAlerts": {
         "enabled": false
       },
-      "prHourlyLimit": 0
+      "prHourlyLimit": 0,
+      "prBodyNotes": [
+        "See full list of changes [here]({{repositoryUrl}}/compare/{{currentValue}}...{{newValue}})."
+      ]
     }
   },
   "release": {


### PR DESCRIPTION
Currently renovate only includes version to version diff links. This'll add an extra note that includes a link of all the changes. 

I found documentation on the feature [here](https://renovatebot.com/docs/configuration-options/#prbodynotes) and I found the variables I could access from [here](https://github.com/renovatebot/renovate/blob/608d8c5be081cd8f001f64c632aca87db0ceedb0/lib/config/templates/default/pr-body.hbs).