### PR TITLE
Ensure deploy ci step relies on tests completing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,3 +38,4 @@ workflows:
                 - master
           requires:
             - update-cache
+            - test


### PR DESCRIPTION
I was looking at a workflow and noticed there wasn't a line connecting tests to deploy. 

![image](https://user-images.githubusercontent.com/3087225/48740647-4c6e2780-ec26-11e8-8c83-21f78d2fd85f.png)

That meant that the deployment could happen without the tests passing, which was _not_ intentional.

Fixed now!