### PR TITLE
[PATCH config] remove limits on PRs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,7 @@
   "extends": ["config:base"],
   "automerge": true,
   "assignees": ["zephraph"],
-  "commitMessagePrefix": "[PATCH deps]"
+  "commitMessagePrefix": "[PATCH deps]",
+  "prHourlyLimit": 0,
+  "prConcurrentLimit": 0
 }


### PR DESCRIPTION
_config:base_ adds some restrictions on how many concurrent PRs can be open. This removes those so it can open as many PRs as it needs. This applies only to this repository's configuration, not to other projects.