### PR TITLE
Enable updating node versions inside of docker files

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,11 @@
       "prBodyNotes": [
         "See full list of changes [here]({{repositoryUrl}}/compare/v{{currentValue}}...v{{newValue}})."
       ]
+    },
+    "node": {
+      "enabledManagers": [
+        "docker"
+      ]
     }
   },
   "release": {


### PR DESCRIPTION
Adds a new artsy config that can be used to enable updating node. For now it just targets docker images for hokusai projects. 