### PR TITLE
Fix the full list changes link

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
       },
       "prHourlyLimit": 0,
       "prBodyNotes": [
-        "See full list of changes [here]({{repositoryUrl}}/compare/v{{currentValue}}...v{{newValue}})."
+        "See full list of changes [here]({{sourceUrl}}/compare/v{{currentValue}}...v{{newValue}})."
       ]
     },
     "node": {


### PR DESCRIPTION
@rarkins [made an update](https://github.com/renovatebot/renovate/commit/772bc176037e377369e94018f7d44eb19393736f) that changed `repositoryUrl` to `sourceUrl`. This PR should fix our PR show-more links. 

By the way @rarkins, this might be a good thing to actually put in the main PR template. Here's an example of it in use: https://github.com/artsy/positron/pull/1810