### PR TITLE
Set default timezone to EST for consistent use of schedules

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
       "prHourlyLimit": 0,
       "prBodyNotes": [
         "See full list of changes [here]({{sourceUrl}}/compare/v{{currentValue}}...v{{newValue}})."
-      ]
+      ],
+      "timezone": "America/New_York"
     },
     "node": {
       "enabledManagers": [


### PR DESCRIPTION
<img width="744" alt="screen shot 2018-12-20 at 12 33 56 pm" src="https://user-images.githubusercontent.com/796573/50301800-48683c00-0456-11e9-8a4a-31815e08519b.png">

Volt uses the [`nonOfficeHours`](https://github.com/artsy/volt/blob/9ea77bf8d1f91c54232281b8428ef9543781b4e8/renovate.json#L4) preset for scheduling and it's in UTC, which might compete with real people, given a Volt build tends to take some time.

[Timezone][1] is used for setting schedules, and the [default][2] is the timezone of the machine that renovate is running on. It's probably better to have a consistent timezone across organization and each app can override it locally if needed.

This sets the default to the timezone of Artsy HQ.


[1]: https://renovatebot.com/docs/configuration-options/#timezone
[2]: https://renovatebot.com/docs/faq/#control-renovates-schedule