### PR TITLE
Make auto dependency updates not release a new version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,8 @@
   "automerge": true,
   "assignees": ["zephraph"],
   "prHourlyLimit": 0,
-  "prConcurrentLimit": 0
+  "prConcurrentLimit": 0,
+  "labels": [
+    "Version: Trivial"
+  ]
 }


### PR DESCRIPTION
This'll make all the automatic updates to the dev dependencies in this project have the `Trivial` tag and therefore not release. It causes a lot of noise and none of the actual deployable artifacts actually change. 