### PR TITLE
Enable circleci updating via renovate

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
         }
       ],
       "enabledManagers": [
-        "npm"
+        "npm",
+        "circleci"
       ],
       "vulnerabilityAlerts": {
         "enabled": false

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,6 @@
   "assignees": ["zephraph"],
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
-  "enabledManagers": ["npm", "circleci"],
   "labels": [
     "Version: Trivial"
   ]


### PR DESCRIPTION
Removes an unnecessary config update to this project (circleci updates are enabled by default) and enables it on the default artsy renovate config. Updating all the orbs..