### PR TITLE
Add auto-release PR check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,34 +1,15 @@
 version: 2.1
 
 orbs:
-  node: artsy/node@0.1.0
   yarn: artsy/yarn@0.0.5
-
-jobs:
-  test:
-    executor: node/build
-    steps:
-      - yarn/setup
-      - run: yarn test
-  deploy:
-    executor: node/build
-    steps:
-      - add_ssh_keys
-      - yarn/setup
-      # Setup the .npmrc with the proper registry and auth token to publish
-      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-      - run: yarn release
-  update-cache:
-    executor: node/build
-    steps:
-      - yarn/update_dependencies
 
 workflows:
   build_and_verify:
     jobs:
-      - update-cache
-      - test
-      - deploy:
+      - yarn/update-cache
+      - yarn/auto-pr-check
+      - yarn/test
+      - yarn/deploy:
           # The deploy job is the _only_ job that should have access to our npm
           # tokens. We include a context that has our publish credentials
           # explicitly in this step. https://circleci.com/docs/2.0/contexts/
@@ -38,5 +19,6 @@ workflows:
               only:
                 - master
           requires:
-            - update-cache
-            - test
+            - yarn/update-cache
+            - yarn/test
+            - yarn/auto-pr-check

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  yarn: artsy/yarn@0.0.6
+  yarn: artsy/yarn@0.0.7
 
 workflows:
   build_and_verify:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ workflows:
       - yarn/update-cache
       - yarn/auto-pr-check
       - yarn/test
-      - yarn/deploy:
+      - yarn/auto-release:
           # The deploy job is the _only_ job that should have access to our npm
           # tokens. We include a context that has our publish credentials
           # explicitly in this step. https://circleci.com/docs/2.0/contexts/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,8 @@ workflows:
   build_and_verify:
     jobs:
       - yarn/update-cache
-      - yarn/auto-pr-check
+      - yarn/auto-pr-check:
+          context: github
       - yarn/test
       - yarn/auto-release:
           # The deploy job is the _only_ job that should have access to our npm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  yarn: artsy/yarn@0.0.5
+  yarn: artsy/yarn@0.0.6
 
 workflows:
   build_and_verify:


### PR DESCRIPTION
This adds a step to the CI build that runs [auto pr-check](https://intuit.github.io/auto-release/pages/auto-pr-check.html). It'll give us early warning of any issues with auto-check as well as generally just making sure the labels are set correctly on this repo. 