### PR TITLE
Make all devDependency updates marked as trivial

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,14 @@
             "auto-release-cli"
           ],
           "enabled": false
+        },
+        {
+          "depTypeList": [
+            "devDependencies"
+          ],
+          "labels": [
+            "Version: Trivial"
+          ]
         }
       ],
       "enabledManagers": [


### PR DESCRIPTION
This adds a new package rule to (hopefully) mark all `devDependency` updates as `Version: Trivial`. This is to preserve my sanity, ha. 