### PR TITLE
Remove automatic updating of auto-release-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,9 +38,6 @@
           "excludePackagePatterns": [
             "^@artsy"
           ],
-          "excludePackageNames": [
-            "auto-release-cli"
-          ],
           "enabled": false
         },
         {


### PR DESCRIPTION
This is intended to be merged in conjunction with https://github.com/artsy/orbs/pull/17. It'll remove the updating of `auto-release-cli` by renovate. Post this PR I'll remove `auto-release-cli` as a direct dependency from each of our projects. 