### PR TITLE
Don't deploy trivial changes

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -6,7 +6,7 @@
     "major": "Version: Major",
     "minor": "Version: Minor",
     "patch": "Version: Patch",
-    "internal": "Version: Trivial",
-    "skip-release": "Skip Release"
-  }
+    "internal": "Version: Trivial"
+  },
+  "skipReleaseLabels": ["Version: Trivial", "Skip Release"]
 }


### PR DESCRIPTION
Trivial changes deployed on the last release... this ensures they won't.