### PR TITLE
Explicitly ignore artsy/hokusai in circleci config

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,9 @@
         "npm",
         "circleci"
       ],
+      "ignoreDeps": [
+        "artsy/hokusai"
+      ],
       "vulnerabilityAlerts": {
         "enabled": false
       },


### PR DESCRIPTION
Fixes #152

When I enabled circleci updates so that our orbs would get bumped it also started bumping docker images in the circleci config. I could explicitly ignore them all, but `artsy/hokusai` is the one that's cropped up a few times. This'll just make sure we ignore it going forward. We can always remove this property if it's needed later.