### PR TITLE
Automerge auto config and yarn orb

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,11 +69,17 @@
         {
           "packageNames": ["yarn"],
           "depTypeList": ["orb"],
-          "automerge": true
+          "automerge": true,
+          "major": {
+            "automerge": false
+          }
         },
         {
           "packageNames": ["@artsy/auto-config"],
-          "automerge": true
+          "automerge": true,
+          "major": {
+            "automerge": false
+          }
         }
       ],
       "enabledManagers": [

--- a/package.json
+++ b/package.json
@@ -65,6 +65,15 @@
           "labels": [
             "Version: Trivial"
           ]
+        },
+        {
+          "packageNames": ["yarn"],
+          "depTypeList": ["orb"],
+          "automerge": true
+        },
+        {
+          "packageNames": ["@artsy/auto-config"],
+          "automerge": true
         }
       ],
       "enabledManagers": [


### PR DESCRIPTION
When an update happens to our configs, we should auto update. This will _only_ apply to minor or patch updates. Major updates will still need to be manually merged (because it might be a breaking change for the project). 