### PR TITLE
Run yarn dedupe on dependency updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,9 @@
         "npm",
         "circleci"
       ],
+      "postUpdateOptions": [
+        "yarnDedupeHighest"
+      ],
       "ignoreDeps": [
         "artsy/hokusai"
       ],


### PR DESCRIPTION
This runs [yarn-deduplicate](https://github.com/atlassian/yarn-deduplicate) (with the `highest` option) when updating dependencies w/ renovate. 

See the docs [here](https://renovatebot.com/docs/configuration-options/#postupdateoptions).