### PR TITLE
Remove dedupe process from renovate

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,9 +92,6 @@
         "npm",
         "circleci"
       ],
-      "postUpdateOptions": [
-        "yarnDedupeHighest"
-      ],
       "ignoreDeps": [
         "artsy/hokusai"
       ],


### PR DESCRIPTION
The dedupe process is _potentially_ causing issues, specifically in positron. I'm disabling it to see if it has any effect. 