### PR TITLE
Make approval workflow duplicate of default

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   },
   "renovate-config": {
     "approval": {
-      "extends": [
-        "@artsy"
+     "extends": [
+        "config:base"
       ],
       "packageRules": [
         {
@@ -45,8 +45,65 @@
           ],
           "enabled": true,
           "masterIssueApproval": true
+        },
+        {
+          "managers": [
+            "npm"
+          ],
+          "depTypeList": [
+            "engines"
+          ],
+          "packagePatterns": [
+            "*"
+          ],
+          "enabled": false
+        },
+        {
+          "depTypeList": [
+            "devDependencies",
+            "orb"
+          ],
+          "labels": [
+            "Version: Trivial"
+          ]
+        },
+        {
+          "packageNames": [
+            "yarn"
+          ],
+          "depTypeList": [
+            "orb"
+          ],
+          "automerge": true,
+          "major": {
+            "automerge": false
+          }
+        },
+        {
+          "packageNames": [
+            "@artsy/auto-config"
+          ],
+          "automerge": true,
+          "major": {
+            "automerge": false
+          }
         }
-      ]
+      ],
+      "enabledManagers": [
+        "npm",
+        "circleci"
+      ],
+      "ignoreDeps": [
+        "artsy/hokusai"
+      ],
+      "vulnerabilityAlerts": {
+        "enabled": false
+      },
+      "prHourlyLimit": 0,
+      "prBodyNotes": [
+        "See full list of changes [here]({{sourceUrl}}/compare/v{{currentValue}}...v{{newValue}})."
+      ],
+      "timezone": "America/New_York"
     },
     "default": {
       "extends": [


### PR DESCRIPTION
For whatever reason the approval workflow wasn't doing what I expected. My hunch is that even though I was extending the default workflow, the rule in approval _wasn't_ overriding the rule in default. 

For now I've just copied the whole thing. Hopefully this'll correctly enable the approval workflow. 