### PR TITLE
Remove global master issue flag as it's no longer needed

### DIFF
--- a/lib/config-builder.js
+++ b/lib/config-builder.js
@@ -10,7 +10,6 @@ const getCommitMessageExtraDefault = () => {
 
 // Use the master approval workflow for any non-artsy dependencies
 const issueApproval = {
-  masterIssue: true,
   packageRules: [
     {
       managers: ["npm"],

--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
       ],
       "commitMessageTopic": "dep {{depName}}",
       "commitMessageExtra": "from {{{currentVersion}}} to {{#if isMajor}}v{{{newMajor}}}{{else}}{{#if isSingleVersion}}v{{{toVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}}",
-      "masterIssue": true,
       "packageRules": [
         {
           "managers": [


### PR DESCRIPTION
@rarkins [fixed the issue](https://github.com/renovatebot/renovate/commit/1dfcc4ef3d043ef1dc96c64eab512c597d7664f9) that required the `masterIssue` flag on the top level config to get the `masterIssueApproval` workflow to work. 