### PR TITLE
Don't use version label on apps

### DIFF
--- a/lib/config-builder.js
+++ b/lib/config-builder.js
@@ -38,6 +38,7 @@ const ignoreEngineUpdates = {
 };
 
 // Automatically assign the trivial label to any devDependency or orb updates
+// Should only be applied to libs
 const trivialLabel = {
   packageRules: [
     {
@@ -92,7 +93,6 @@ const shared = merge.all([
   commitMessage,
   issueApproval,
   ignoreEngineUpdates,
-  trivialLabel,
   orbUpdates,
   autoConfigUpdates
 ]);
@@ -101,9 +101,12 @@ const app = {
   extends: [":pinAllExceptPeerDependencies", "@artsy:shared"]
 };
 
-const lib = {
-  extends: [":pinOnlyDevDependencies", "@artsy:shared"]
-};
+const lib = merge.all([
+  ({
+    extends: [":pinOnlyDevDependencies", "@artsy:shared"]
+  },
+  trivialLabel)
+]);
 
 /**
  * TODO: Remove this once everything is converted over to app/lib

--- a/package.json
+++ b/package.json
@@ -38,9 +38,16 @@
       ]
     },
     "lib": {
-      "extends": [
-        ":pinOnlyDevDependencies",
-        "@artsy:shared"
+      "packageRules": [
+        {
+          "depTypeList": [
+            "devDependencies",
+            "orb"
+          ],
+          "labels": [
+            "Version: Trivial"
+          ]
+        }
       ]
     },
     "shared": {
@@ -93,15 +100,6 @@
             "*"
           ],
           "enabled": false
-        },
-        {
-          "depTypeList": [
-            "devDependencies",
-            "orb"
-          ],
-          "labels": [
-            "Version: Trivial"
-          ]
         },
         {
           "packageNames": [


### PR DESCRIPTION
Just upgraded metaphysics to use the `@artsy:app` preset and it added a trivial label to one of the PRs. 

I removed it from the shared preset so it's not applied to apps. 