### PR TITLE
auto merge minors by default, make artsy specific pr comments

### DIFF
--- a/lib/config-builder.js
+++ b/lib/config-builder.js
@@ -16,11 +16,7 @@ const issueApproval = {
       depTypeList: ["dependencies", "devDependencies", "peerDependencies"],
       packagePatterns: ["*"],
       excludePackagePatterns: ["^@artsy"],
-      masterIssueApproval: true,
-      automerge: true,
-      major: {
-        automerge: false
-      }
+      masterIssueApproval: true
     }
   ]
 };
@@ -53,11 +49,7 @@ const orbUpdates = {
   packageRules: [
     {
       packageNames: ["yarn", "node"],
-      depTypeList: ["orb"],
-      automerge: true,
-      major: {
-        automerge: false
-      }
+      depTypeList: ["orb"]
     }
   ]
 };
@@ -66,11 +58,16 @@ const orbUpdates = {
 const autoConfigUpdates = {
   packageRules: [
     {
-      packageNames: ["@artsy/auto-config"],
-      automerge: true,
-      major: {
-        automerge: false
-      }
+      packageNames: ["@artsy/auto-config"]
+    }
+  ]
+};
+
+const artsyPRs = {
+  packageRules: [
+    {
+      packagePatterns: ["^@artsy"],
+      prBodyNotes: ["See full list of changes [here]({{sourceUrl}}/compare/v{{currentValue}}...v{{newValue}})."]
     }
   ]
 };
@@ -88,13 +85,17 @@ const shared = merge.all([
     enabledManagers: ["npm", "circleci"],
     ignoreDeps: ["artsy/hokusai"],
     timezone: "America/New_York",
-    prBodyNotes: ["See full list of changes [here]({{sourceUrl}}/compare/v{{currentValue}}...v{{newValue}})."]
+    automerge: true,
+    major: {
+      automerge: false
+    }
   },
   commitMessage,
   issueApproval,
   ignoreEngineUpdates,
   orbUpdates,
-  autoConfigUpdates
+  autoConfigUpdates,
+  artsyPRs
 ]);
 
 const app = {

--- a/package.json
+++ b/package.json
@@ -62,9 +62,10 @@
         "artsy/hokusai"
       ],
       "timezone": "America/New_York",
-      "prBodyNotes": [
-        "See full list of changes [here]({{sourceUrl}}/compare/v{{currentValue}}...v{{newValue}})."
-      ],
+      "automerge": true,
+      "major": {
+        "automerge": false
+      },
       "commitMessageTopic": "dep {{depName}}",
       "commitMessageExtra": "from {{{currentVersion}}} to {{#if isMajor}}v{{{newMajor}}}{{else}}{{#if isSingleVersion}}v{{{toVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}}",
       "packageRules": [
@@ -83,11 +84,7 @@
           "excludePackagePatterns": [
             "^@artsy"
           ],
-          "masterIssueApproval": true,
-          "automerge": true,
-          "major": {
-            "automerge": false
-          }
+          "masterIssueApproval": true
         },
         {
           "managers": [
@@ -108,20 +105,20 @@
           ],
           "depTypeList": [
             "orb"
-          ],
-          "automerge": true,
-          "major": {
-            "automerge": false
-          }
+          ]
         },
         {
           "packageNames": [
             "@artsy/auto-config"
+          ]
+        },
+        {
+          "packagePatterns": [
+            "^@artsy"
           ],
-          "automerge": true,
-          "major": {
-            "automerge": false
-          }
+          "prBodyNotes": [
+            "See full list of changes [here]({{sourceUrl}}/compare/v{{currentValue}}...v{{newValue}})."
+          ]
         }
       ]
     },


### PR DESCRIPTION
This makes auto-merging non-major changes automatic across the board. Also it moves the `See full changes...` PR comment that's specific to our dependencies to an artsy only package rule. 