### PR TITLE
Create a group for non-artsy dependencies

### DIFF
--- a/lib/config-builder.js
+++ b/lib/config-builder.js
@@ -16,7 +16,8 @@ const issueApproval = {
       depTypeList: ["dependencies", "devDependencies", "peerDependencies"],
       packagePatterns: ["*"],
       excludePackagePatterns: ["^@artsy"],
-      masterIssueApproval: true
+      masterIssueApproval: true,
+      groupName: ["non-artsy dependencies"]
     }
   ]
 };

--- a/package.json
+++ b/package.json
@@ -84,7 +84,10 @@
           "excludePackagePatterns": [
             "^@artsy"
           ],
-          "masterIssueApproval": true
+          "masterIssueApproval": true,
+          "groupName": [
+            "non-artsy dependencies"
+          ]
         },
         {
           "managers": [


### PR DESCRIPTION
This'll group all the dependencies we check in the master approval list into a single PR. 