### PR TITLE
Always default to trivial on dep updates

### DIFF
--- a/lib/config-builder.js
+++ b/lib/config-builder.js
@@ -25,6 +25,7 @@ const issueApproval = {
       excludePackagePatterns: ["^@artsy"],
       masterIssueApproval: true,
       groupName: ["non-artsy dependencies"],
+      labels: ["Version: Trivial"],
       ...autoMerge
     }
   ]

--- a/package.json
+++ b/package.json
@@ -88,6 +88,9 @@
           "groupName": [
             "non-artsy dependencies"
           ],
+          "labels": [
+            "Version: Trivial"
+          ],
           "automerge": true,
           "major": {
             "automerge": false


### PR DESCRIPTION
There's not any way to smartly determine if a dependency update constitutes a breaking change and we generally don't want to release when there's a dependency update so always just set it to trivial. 