### PR TITLE
Fix malformed @artsy:lib config

### DIFF
--- a/lib/config-builder.js
+++ b/lib/config-builder.js
@@ -23,10 +23,7 @@ const issueApproval = {
       depTypeList: ["dependencies", "devDependencies", "peerDependencies"],
       packagePatterns: ["*"],
       excludePackagePatterns: ["^@artsy"],
-      masterIssueApproval: true,
-      groupName: ["non-artsy dependencies"],
-      labels: ["Version: Trivial"],
-      ...autoMerge
+      masterIssueApproval: true
     }
   ]
 };
@@ -48,7 +45,7 @@ const ignoreEngineUpdates = {
 const trivialLabel = {
   packageRules: [
     {
-      depTypeList: ["devDependencies", "orb"],
+      depTypeList: ["dependencies", "peerDependencies", "devDependencies", "orb"],
       labels: ["Version: Trivial"]
     }
   ]
@@ -59,18 +56,7 @@ const orbUpdates = {
   packageRules: [
     {
       packageNames: ["yarn", "node"],
-      depTypeList: ["orb"],
-      ...autoMerge
-    }
-  ]
-};
-
-// Automatically update @artsy/auto-config
-const autoConfigUpdates = {
-  packageRules: [
-    {
-      packageNames: ["@artsy/auto-config"],
-      ...autoMerge
+      depTypeList: ["orb"]
     }
   ]
 };
@@ -79,8 +65,7 @@ const artsyPRs = {
   packageRules: [
     {
       packagePatterns: ["^@artsy"],
-      prBodyNotes: ["See full list of changes [here]({{sourceUrl}}/compare/v{{currentValue}}...v{{newValue}})."],
-      ...autoMerge
+      prBodyNotes: ["See full list of changes [here]({{sourceUrl}}/compare/v{{currentValue}}...v{{newValue}})."]
     }
   ]
 };
@@ -104,19 +89,20 @@ const shared = merge.all([
   issueApproval,
   ignoreEngineUpdates,
   orbUpdates,
-  autoConfigUpdates,
   artsyPRs
 ]);
 
-const app = {
-  extends: [":pinAllExceptPeerDependencies", "@artsy:shared"]
-};
+const app = merge.all([
+  {
+    extends: [":pinAllExceptPeerDependencies", "@artsy:shared"]
+  }
+]);
 
 const lib = merge.all([
-  ({
+  {
     extends: [":pinOnlyDevDependencies", "@artsy:shared"]
   },
-  trivialLabel)
+  trivialLabel
 ]);
 
 /**

--- a/package.json
+++ b/package.json
@@ -38,9 +38,15 @@
       ]
     },
     "lib": {
+      "extends": [
+        ":pinOnlyDevDependencies",
+        "@artsy:shared"
+      ],
       "packageRules": [
         {
           "depTypeList": [
+            "dependencies",
+            "peerDependencies",
             "devDependencies",
             "orb"
           ],
@@ -84,17 +90,7 @@
           "excludePackagePatterns": [
             "^@artsy"
           ],
-          "masterIssueApproval": true,
-          "groupName": [
-            "non-artsy dependencies"
-          ],
-          "labels": [
-            "Version: Trivial"
-          ],
-          "automerge": true,
-          "major": {
-            "automerge": false
-          }
+          "masterIssueApproval": true
         },
         {
           "managers": [
@@ -115,20 +111,7 @@
           ],
           "depTypeList": [
             "orb"
-          ],
-          "automerge": true,
-          "major": {
-            "automerge": false
-          }
-        },
-        {
-          "packageNames": [
-            "@artsy/auto-config"
-          ],
-          "automerge": true,
-          "major": {
-            "automerge": false
-          }
+          ]
         },
         {
           "packagePatterns": [
@@ -136,11 +119,7 @@
           ],
           "prBodyNotes": [
             "See full list of changes [here]({{sourceUrl}}/compare/v{{currentValue}}...v{{newValue}})."
-          ],
-          "automerge": true,
-          "major": {
-            "automerge": false
-          }
+          ]
         }
       ]
     },

--- a/tests/validate-config.test.js
+++ b/tests/validate-config.test.js
@@ -16,6 +16,16 @@ describe("@artsy/renovate-config", () => {
     expect(renovateConfig["default"]).toBeDefined();
   });
 
+  it(`"renovate-config" has "lib" and it extends shared`, async () => {
+    expect(renovateConfig.lib).toBeDefined();
+    expect(renovateConfig.lib.extends.includes("@artsy:shared")).toBeTruthy();
+  });
+
+  it(`"renovate-config" has "app" and it extends shared`, async () => {
+    expect(renovateConfig.app).toBeDefined();
+    expect(renovateConfig.app.extends.includes("@artsy:shared")).toBeTruthy();
+  });
+
   Object.keys(renovateConfig).forEach(assertConfig);
 
   function assertConfig(name) {


### PR DESCRIPTION
The `lib` config was absolutely borked. I messed up some object merging in the generation and `lib` stopped extending from `shared` which is where all the rules live. It basically turned it into a raw instance of renovate. 

I've got a test in place now to ensure that doesn't happen again. 