### PR TITLE
@zephraph => Add basic ruby config

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,9 +60,13 @@
       "extends": [
         ":disableRateLimiting"
       ],
+      "bundler": {
+        "enabled": true
+      },
       "enabledManagers": [
         "npm",
-        "circleci"
+        "circleci",
+        "bundler"
       ],
       "ignoreDeps": [
         "artsy/hokusai"


### PR DESCRIPTION
I'm not sure if this is right. The bundler enable config is required since it's [still in alpha](https://renovatebot.com/docs/ruby/), and then looks like since we use an allowlist via `enabledManagers`, I needed to add it there.

The hope is then a `renovate.json` added to Rosalind:

```
{
  "extends": ["@artsy:shared"],
  "assignees": ["mzikherman"]
}
```

will trigger the initial onboarding PR and then updates.