### PR TITLE
@zephraph => Add ruby support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ The renovate config presets are stored in this projects package.json.
 
 ## Steps to add/modify configs
 
-- Add/modify code in `generate-config.js`.
+- Add/modify code in `config-builder.js`.
 - Run `yarn generate-config`.
 - Run `yarn jest`.

--- a/README.md
+++ b/README.md
@@ -17,3 +17,9 @@ Your `renovate.json` file might look something like this
 Where `@artsy` is the `default` renovate config, and `@artsy:example` is the `example` renovate config (which doesn't actually exist).
 
 The renovate config presets are stored in this projects package.json.
+
+## Steps to add/modify configs
+
+- Add/modify code in `generate-config.js`.
+- Run `yarn generate-config`.
+- Run `yarn jest`.

--- a/lib/config-builder.js
+++ b/lib/config-builder.js
@@ -81,7 +81,8 @@ const commitMessage = {
 const shared = merge.all([
   {
     extends: [":disableRateLimiting"],
-    enabledManagers: ["npm", "circleci"],
+    enabledManagers: ["npm", "circleci", "bundler"],
+    bundler: { enabled: true },
     ignoreDeps: ["artsy/hokusai"],
     timezone: "America/New_York",
     ...autoMerge

--- a/package.json
+++ b/package.json
@@ -62,8 +62,12 @@
       ],
       "enabledManagers": [
         "npm",
-        "circleci"
+        "circleci",
+        "bundler"
       ],
+      "bundler": {
+        "enabled": true
+      },
       "ignoreDeps": [
         "artsy/hokusai"
       ],


### PR DESCRIPTION
I'm not sure if this is right. The bundler enable config is required since it's [still in alpha](https://renovatebot.com/docs/ruby/), and then looks like since we use an allowlist via `enabledManagers`, I needed to add it there.

The hope is then a `renovate.json` added to Rosalind:

```
{
  "extends": ["@artsy:shared"],
  "assignees": ["mzikherman"]
}
```

will trigger the initial onboarding PR and then updates.