### PR TITLE
Don't do security PRs w/ renovate

### DIFF
--- a/lib/config-builder.js
+++ b/lib/config-builder.js
@@ -71,6 +71,13 @@ const artsyPRs = {
   ]
 };
 
+// We're using GitHub's functionality for security updates
+const disableSecurityPRs = {
+  vulnerabilityAlerts: {
+    enabled: false
+  }
+};
+
 const commitMessage = {
   commitMessageTopic: "dep {{depName}}",
   commitMessageExtra: `from {{{currentVersion}}} ${getCommitMessageExtraDefault()}`
@@ -86,6 +93,7 @@ const shared = merge.all([
     timezone: "America/New_York",
     ...autoMerge
   },
+  disableSecurityPRs,
   commitMessage,
   issueApproval,
   ignoreEngineUpdates,

--- a/package.json
+++ b/package.json
@@ -72,6 +72,9 @@
       "major": {
         "automerge": false
       },
+      "vulnerabilityAlerts": {
+        "enabled": false
+      },
       "commitMessageTopic": "dep {{depName}}",
       "commitMessageExtra": "from {{{currentVersion}}} to {{#if isMajor}}v{{{newMajor}}}{{else}}{{#if isSingleVersion}}v{{{toVersion}}}{{else}}{{{newValue}}}{{/if}}{{/if}}",
       "packageRules": [


### PR DESCRIPTION
As per [this slack thread](https://artsy.slack.com/archives/CA8SANW3W/p1559161959176500) I've disabled security updates for renovate. 

We're just going to use GitHub's built-in functionality instead. 

cc @dleve123 