### PR TITLE
Rename config, automatically merge pins

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -83,6 +83,14 @@ const commitMessage = {
   commitMessageExtra: `from {{{currentVersion}}} ${getCommitMessageExtraDefault()}`
 };
 
+const autoMergePins = {
+  pin: {
+    masterIssueApproval: false,
+    enabled: true,
+    automerge: true
+  }
+};
+
 // -- END INDIVIDUAL CONFIG OPTIONS --------
 
 const shared = merge.all([
@@ -98,7 +106,8 @@ const shared = merge.all([
   issueApproval,
   ignoreEngineUpdates,
   orbUpdates,
-  artsyPRs
+  artsyPRs,
+  autoMergePins
 ]);
 
 const app = merge.all([

--- a/lib/generate-config.js
+++ b/lib/generate-config.js
@@ -1,6 +1,6 @@
 const fs = require("fs");
 let pkg = require("../package.json");
-const { configs } = require("./config-builder");
+const { configs } = require("./config");
 
 pkg["renovate-config"] = configs;
 

--- a/package.json
+++ b/package.json
@@ -125,7 +125,12 @@
             "See full list of changes [here]({{sourceUrl}}/compare/v{{currentValue}}...v{{newValue}})."
           ]
         }
-      ]
+      ],
+      "pin": {
+        "masterIssueApproval": false,
+        "enabled": true,
+        "automerge": true
+      }
     },
     "default": {
       "extends": [

--- a/tests/validate-config.test.js
+++ b/tests/validate-config.test.js
@@ -1,6 +1,6 @@
 const { initLogger } = require("renovate/dist/logger");
 const { migrateAndValidate } = require("renovate/dist/config/migrate-validate");
-const { getCommitMessageExtraDefault, configs } = require("../lib/config-builder");
+const { getCommitMessageExtraDefault, configs } = require("../lib/config");
 
 initLogger();
 


### PR DESCRIPTION
Renovate has a notion of pinning dependencies. It does this to provide more transparency/consistency around the current version. This puts the versions in the `package.json` in line with the versions of the lock file. 

These changes are non-breaking and it always keeps the same version that's configured in the lock file. Give that, we should just auto merge these PRs. 