### PR TITLE
Fix an issue w/ orbs not getting PRs on major updates

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -57,7 +57,8 @@ const orbUpdates = {
     {
       packagePatterns: ["*"],
       depTypeList: ["orb"],
-      enabled: true
+      enabled: true,
+      major: { enabled: true }
     }
   ]
 };

--- a/package.json
+++ b/package.json
@@ -115,7 +115,10 @@
           "depTypeList": [
             "orb"
           ],
-          "enabled": true
+          "enabled": true,
+          "major": {
+            "enabled": true
+          }
         },
         {
           "packagePatterns": [


### PR DESCRIPTION
I noticed that some of our orb updates weren't getting PRs. After discussing with @rarkins in https://github.com/renovatebot/config-help/issues/300 it seems it might've been inheriting a docker setting that disabled it for major releases. 

I've manually overridden that here. 