### PR TITLE
Group react dependencies together

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,18 +1,23 @@
 version: 2.1
 
 orbs:
-  yarn: artsy/yarn@dev:2.1.0.a05a433b1dbafce8fca128fc94f90967
+  yarn: artsy/yarn@dev:2.1.0
 
 workflows:
   build_and_verify:
     jobs:
       - yarn/update-cache
-      - yarn/test
+      - yarn/jest
+      - yarn/run:
+          name: validate-config
+          description: Validates the renovate configuration
+          script: renovate-config-validator
       - yarn/auto-release:
           context: npm-deploy
           filters:
             branches:
               only: master
           requires:
+            - validate-config
             - yarn/update-cache
             - yarn/test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ workflows:
       - yarn/jest
       - yarn/run:
           name: validate-config
-          description: Validates the renovate configuration
           script: renovate-config-validator
       - yarn/auto-release:
           context: npm-deploy
@@ -20,4 +19,4 @@ workflows:
           requires:
             - validate-config
             - yarn/update-cache
-            - yarn/test
+            - yarn/jest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  yarn: artsy/yarn@dev:2.1.0
+  yarn: artsy/yarn@2.1.0
 
 workflows:
   build_and_verify:

--- a/lib/config.js
+++ b/lib/config.js
@@ -92,6 +92,15 @@ const autoMergePins = {
   }
 };
 
+const groupPackages = {
+  packageRules: [
+    {
+      extends: "monorepo:react",
+      groupName: "react monorepo"
+    }
+  ]
+};
+
 // -- END INDIVIDUAL CONFIG OPTIONS --------
 
 const shared = merge.all([
@@ -108,7 +117,8 @@ const shared = merge.all([
   ignoreEngineUpdates,
   orbUpdates,
   artsyPRs,
-  autoMergePins
+  autoMergePins,
+  groupPackages
 ]);
 
 const app = merge.all([

--- a/package.json
+++ b/package.json
@@ -127,6 +127,10 @@
           "prBodyNotes": [
             "See full list of changes [here]({{sourceUrl}}/compare/v{{currentValue}}...v{{newValue}})."
           ]
+        },
+        {
+          "extends": "monorepo:react",
+          "groupName": "react monorepo"
         }
       ],
       "pin": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "deepmerge": "3.3.0",
     "husky": "3.0.4",
     "jest": "24.9.0",
+    "jest-junit": "^7.0.0",
     "renovate": "19.32.0"
   },
   "husky": {

--- a/tests/validate-config.test.js
+++ b/tests/validate-config.test.js
@@ -1,4 +1,3 @@
-const { migrateAndValidate } = require("renovate/dist/config/migrate-validate");
 const { getCommitMessageExtraDefault, configs } = require("../lib/config");
 
 const pkg = Object.freeze(require("../package.json"));
@@ -31,26 +30,10 @@ describe("@artsy/renovate-config", () => {
       expect(Object.keys(config).length).toBeGreaterThan(0);
     });
 
-    it(`"${name}" is valid`, async () => {
-      const config = renovateConfig[name];
-      const { errors, warnings } = await migrateAndValidate({}, config);
-      expect(errors).toEqual([]);
-      expect(warnings).toEqual([]);
-    });
-
     it(`${name} matches generated config`, () => {
       expect(renovateConfig[name]).toEqual(configs[name]);
     });
   }
-});
-
-describe("renovate.json", () => {
-  it("valid", async () => {
-    const config = require("../renovate.json");
-    const { errors, warnings } = await migrateAndValidate({}, config);
-    expect(errors).toEqual([]);
-    expect(warnings).toEqual([]);
-  });
 });
 
 describe("generate-config", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3117,6 +3117,16 @@ jest-jasmine2@^24.9.0:
     pretty-format "^24.9.0"
     throat "^4.0.0"
 
+jest-junit@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-7.0.0.tgz#e2ab2dc3f4eb2768f3e4c43e4e4cd841133a8c0e"
+  integrity sha512-ljUdO0hLyu0A92xk7R2Wet3kj99fmazTo+ZFYQP6b7AGOBxJUj8ZkJWzJ632ajpXko2Y5oNoGR2kvOwiDdu6hg==
+  dependencies:
+    jest-validate "^24.0.0"
+    mkdirp "^0.5.1"
+    strip-ansi "^4.0.0"
+    xml "^1.0.1"
+
 jest-leak-detector@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-24.9.0.tgz#b665dea7c77100c5c4f7dfcb153b65cf07dcf96a"
@@ -3287,7 +3297,7 @@ jest-util@^24.9.0:
     slash "^2.0.0"
     source-map "^0.6.0"
 
-jest-validate@^24.9.0:
+jest-validate@^24.0.0, jest-validate@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-24.9.0.tgz#0775c55360d173cd854e40180756d4ff52def8ab"
   integrity sha512-HPIt6C5ACwiqSiwi+OfSSHbK8sG7akG8eATl+IPKaeIjtPOeBUd/g3J7DghugzxrGjI93qS/+RPKe1H6PqvhRQ==
@@ -4589,7 +4599,6 @@ npm@6.10.3:
     cmd-shim "~2.0.2"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -4604,7 +4613,6 @@ npm@6.10.3:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.2"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -4623,14 +4631,8 @@ npm@6.10.3:
     libnpx "^10.2.0"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -7049,6 +7051,11 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+
+xml@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha1-eLpyAgApxbyHuKgaPPzXS0ovweU=
 
 xmldoc@1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This groups all the packages from react's official repo into a single dependency update. Useful if we ever want to use renovate to update react. 