### PR TITLE
[config] Create PRs for vscode-apollo-relay

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -2,7 +2,9 @@ const merge = require("deepmerge");
 
 const getCommitMessageExtraDefault = () => {
   const { getOptions } = require("renovate/dist/config/definitions");
-  const commitMessageExtra = getOptions().find(opt => opt.name === "commitMessageExtra");
+  const commitMessageExtra = getOptions().find(
+    opt => opt.name === "commitMessageExtra"
+  );
   return commitMessageExtra.default;
 };
 
@@ -22,7 +24,7 @@ const issueApproval = {
       managers: ["npm"],
       depTypeList: ["dependencies", "devDependencies", "peerDependencies"],
       packagePatterns: ["*"],
-      excludePackagePatterns: ["^@artsy", "^@omakase"],
+      excludePackagePatterns: ["^@artsy", "^@omakase", "^vscode-apollo-relay"],
       masterIssueApproval: true
     }
   ]
@@ -45,7 +47,12 @@ const ignoreEngineUpdates = {
 const trivialLabel = {
   packageRules: [
     {
-      depTypeList: ["dependencies", "peerDependencies", "devDependencies", "orb"],
+      depTypeList: [
+        "dependencies",
+        "peerDependencies",
+        "devDependencies",
+        "orb"
+      ],
       labels: ["Version: Trivial"]
     }
   ]
@@ -67,7 +74,9 @@ const artsyPRs = {
   packageRules: [
     {
       packagePatterns: ["^@artsy"],
-      prBodyNotes: ["See full list of changes [here]({{sourceUrl}}/compare/v{{currentValue}}...v{{newValue}})."]
+      prBodyNotes: [
+        "See full list of changes [here]({{sourceUrl}}/compare/v{{currentValue}}...v{{newValue}})."
+      ]
     }
   ]
 };
@@ -184,7 +193,9 @@ const defaultConfig = {
     enabled: false
   },
   prHourlyLimit: 0,
-  prBodyNotes: ["See full list of changes [here]({{sourceUrl}}/compare/v{{currentValue}}...v{{newValue}})."],
+  prBodyNotes: [
+    "See full list of changes [here]({{sourceUrl}}/compare/v{{currentValue}}...v{{newValue}})."
+  ],
   timezone: "America/New_York"
 };
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
           ],
           "excludePackagePatterns": [
             "^@artsy",
-            "^@omakase"
+            "^@omakase",
+            "^vscode-apollo-relay"
           ],
           "masterIssueApproval": true
         },


### PR DESCRIPTION
In the long run, this would be part of the `@omakase/dev` meta-package, but we’re not even using that yet in Emission.

<!--- AutoPR:START ---> 
---

<img align="left" width="60" src="https://autobot.auto-it.now.sh/public/logo.png"/>

### Choose a release label

This repository uses [auto](https://github.com/intuit/auto) to generate releases. In order to do that, 
it needs an appropriate label assigned to each PR. Choose a label below that you feel best suites your changes.

##

<sub>**Semver Labels** _(choose at most one)_</sub>

- [ ] <!-- autobot:semver:9e53f3dbe1dbfad3297b9902f3c2eb08 --> <img align="center" src="https://autobot.auto-it.now.sh/l/label?color=FA6900&text=Version: Major"/> 
- [x] <!-- autobot:semver:7a50c807ba5223cbc30645e76c55148c --> <img align="center" src="https://autobot.auto-it.now.sh/l/label?color=A7DBD8&text=Version: Minor"/> 
- [ ] <!-- autobot:semver:cde78e506c7273f2f018e0a478081f09 --> <img align="center" src="https://autobot.auto-it.now.sh/l/label?color=E0E4CC&text=Version: Patch"/>

##

<sub>**Skip Release Labels** _(chose at most one)_</sub>

- [ ] <!-- autobot:skipRelease:743685a075cb21b56ba5ae7baae81ecb --> <img align="center" src="https://autobot.auto-it.now.sh/l/label?color=79C8F2&text=Skip Release"/> 
- [ ] <!-- autobot:skipRelease:fde34756cfd117a2dadacf8ceb8ac1ba --> <img align="center" src="https://autobot.auto-it.now.sh/l/label?color=A7DBD8&text=Version: Trivial"/> 
- [ ] <!-- autobot:skipRelease:a3907cd461d8739aa3266047bc4b8c0c --> <img align="center" src="https://autobot.auto-it.now.sh/l/label?color=ECF279&text=Docs"/>

<sub>_Generated by [auto-it](https://github.com/apps/auto-it)_</sub>
<!--- AutoPR:END --->