### PR TITLE
Add resolutions to the master issue approval flow

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -22,7 +22,7 @@ const issueApproval = {
   packageRules: [
     {
       managers: ["npm"],
-      depTypeList: ["dependencies", "devDependencies", "peerDependencies"],
+      depTypeList: ["dependencies", "devDependencies", "peerDependencies", "resolutions"],
       packagePatterns: ["*"],
       excludePackagePatterns: ["^@artsy", "^@omakase"],
       masterIssueApproval: true,

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
           "depTypeList": [
             "dependencies",
             "devDependencies",
-            "peerDependencies"
+            "peerDependencies",
+            "resolutions"
           ],
           "packagePatterns": [
             "*"


### PR DESCRIPTION
Some extra context here: https://artsy.slack.com/archives/CP9P4KR35/p1587502585324600

There were some resolutions added to radiation that automatically got renovate PRs opened for them. This was unexpected. It seems like `resolutions` was added as a new depTypeList in https://github.com/renovatebot/renovate/pull/5689.

We added it to our generate master issue approval flow so updates to this will get triggered in the issue update but won't spawn a new PR. 