### PR TITLE
fix: avoid auto-merging breaking typescript upgrades

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -39,7 +39,7 @@ const allowedAutoMerge = {
     {
       managers: ["npm"],
       automerge: true,
-      packageNames: ["typescript", "vscode-apollo-relay"],
+      packageNames: ["vscode-apollo-relay"],
       enabled: true,
       masterIssueApproval: false
     },

--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
           ],
           "automerge": true,
           "packageNames": [
-            "typescript",
             "vscode-apollo-relay"
           ],
           "enabled": true,


### PR DESCRIPTION
Typescript does not follow semantic versioning, so minor upgrades have been auto-merged and disrupted our release pipelines on [multiple](https://github.com/artsy/force/pull/12111) [occasions](https://github.com/artsy/force/pull/10850) and [across](https://github.com/artsy/prediction/pull/1225) different projects.

I _think_ this will continue to allow renovate to make upgrade PRs, but they won't be auto-merged. Not sure how to test it though.